### PR TITLE
Have the Web Audio API perform downmixing, and fix code when no input is playing

### DIFF
--- a/dattorroReverb.js
+++ b/dattorroReverb.js
@@ -152,15 +152,18 @@ class DattorroReverb extends AudioWorkletProcessor {
 			dr   = parameters.dry[0]                 ;
 
 		let lIn  = inputs[0][0],
-			rIn  = inputs[0][1],
 			lOut = outputs[0][0],
 			rOut = outputs[0][1];
 
-		// write to predelay
-		this._preDelay.set(
-			Float32Array.from(inputs[0][0], (n, i) => (n + inputs[0][1][i]) * 0.5),
-			this._pDWrite
-		);
+		// write to predelay, or fill pre-delay with silence if no input
+		if (inputs[0].length != 0) {
+			this._preDelay.set(
+				inputs[0][0],
+				this._pDWrite
+			);
+		} else {
+			this._preDelay.fill(0, this._pDWrite, this._pDWrite + 128);
+		}
 
 		let i = 0;
 		while (i < 128) {
@@ -210,9 +213,13 @@ class DattorroReverb extends AudioWorkletProcessor {
 				- this.readDelayAt(10, this._taps[12])
 				- this.readDelayAt(11, this._taps[13]);
 
-			// write
-			lOut[i] = lIn[i] * dr + lo * we;
-			rOut[i] = rIn[i] * dr + ro * we;
+			lOut[i] = lo * we;
+			rOut[i] = ro * we;
+
+			if (lIn) {
+				lOut[i] += lIn[i] * dr;
+				rOut[i] += lIn[i] * dr;
+			}
 
 			i++;
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@ Promise.all([
 	let mg = aC.createGain();
 	let mx = aC.createGain();
 
-	let reverb = new AudioWorkletNode(aC, 'DattorroReverb');
+	let reverb = new AudioWorkletNode(aC, 'DattorroReverb', { channelCountMode: "explicit", channelCount: 1, outputChannelCount: [2] });
 	
 	esrc.forEach(src => src.connect(mx));
 	mg.connect(reverb);


### PR DESCRIPTION
The Web Audio API has all of this built-in (and quite optimized) so I used it: it now down-mixes it like the original paper said (mentioned in https://github.com/khoin/DattorroReverbNode/issues/2#issuecomment-530930008).

The main problem is that the spec says that `input[0][0]` must be undefined when the node has no input, this wasn't taken into account, and it worked because of a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1060579#c1).

With this patch, it works great in [Firefox Nightly](https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly) (for now you need to enable AudioWorklet in `about:config`: `dom.audioworklet.enabled` to `true`).